### PR TITLE
Fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ get('/get-jwt-token', function (req, res) {
 
 __0.1.2__
 * Moving from a monorepo to a standard repo 
-* Remove `@signauth/crypto` to use `@secrez/core` instead
+* Remove `@signauth/crypto` to use `@secrez/crypto` instead
 
 __0.0.5__
 * Using the nonce properly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signauth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/**/*.js'",


### PR DESCRIPTION
Fix README: Signauth depends on @secrez/crypto, not on @secrez/core